### PR TITLE
Double quotes should be single

### DIFF
--- a/src/Data/Struct/Internal.hs
+++ b/src/Data/Struct/Internal.hs
@@ -133,7 +133,7 @@ readMutableByteArraySmallArray# m i s = unsafeCoerce# readSmallArray# m i s
 -- * Field Accessors
 --------------------------------------------------------------------------------
 
--- | A "Slot" is a reference to another unboxed mutable object.
+-- | A 'Slot' is a reference to another unboxed mutable object.
 data Slot x y = Slot
   (forall s. SmallMutableArray# s Any -> State# s -> (# State# s, SmallMutableArray# s Any #))
   (forall s. SmallMutableArray# s Any -> SmallMutableArray# s Any -> State# s -> State# s)
@@ -163,7 +163,7 @@ set :: (PrimMonad m, Struct x, Struct y) => Slot x y -> x (PrimState m) -> y (Pr
 set (Slot _ go) x y = primitive_ (go (destruct x) (destruct y))
 {-# INLINE set #-}
 
--- | A "Field" is a reference from a struct to a normal Haskell data type.
+-- | A 'Field' is a reference from a struct to a normal Haskell data type.
 data Field x a = Field
   (forall s. SmallMutableArray# s Any -> State# s -> (# State# s, a #))
   (forall s. SmallMutableArray# s Any -> a -> State# s -> State# s)


### PR DESCRIPTION
We're referring to a type not a module
