### PR TITLE
Write construct and destruct in terms of Coercible

### DIFF
--- a/src/Data/Struct/Internal/Label.hs
+++ b/src/Data/Struct/Internal/Label.hs
@@ -54,8 +54,7 @@ newtype Label s = Label (Object s)
 
 instance Eq (Label s) where (==) = eqStruct
 
-instance Struct Label where
-  struct _ = Dict
+instance Struct Label
 
 -- | Construct an explicit list labeling structure.
 --

--- a/src/Data/Struct/Internal/LinkCut.hs
+++ b/src/Data/Struct/Internal/LinkCut.hs
@@ -75,8 +75,7 @@ import Data.Struct.Internal
 -- True
 newtype LinkCut a s = LinkCut (Object s)
 
-instance Struct (LinkCut a) where
-  struct _ = Dict
+instance Struct (LinkCut a)
 
 instance Eq (LinkCut a s) where
   (==) = eqStruct

--- a/src/Data/Struct/Internal/Order.hs
+++ b/src/Data/Struct/Internal/Order.hs
@@ -42,8 +42,7 @@ newtype Order s = Order { runOrder :: Object s }
 
 instance Eq (Order s) where (==) = eqStruct
 
-instance Struct Order where
-  struct _ = Dict
+instance Struct Order
 
 key :: Field Order Key
 key = field 0


### PR DESCRIPTION
The proxy argument was removed from 'struct' because it was
not needed. A default implementation of 'struct' was added.

I looked at some core generated after this change and things
seemed to inline neatly without leaving behind any MkCoercible
cases.
