### PR TITLE
Use cabal-doctest-1.0.1

### DIFF
--- a/structs.cabal
+++ b/structs.cabal
@@ -25,7 +25,7 @@ custom-setup
   setup-depends:
     base          >= 4.9 && <5,
     Cabal         >= 1.10,
-    cabal-doctest >= 1 && <1.1
+    cabal-doctest >= 1.0.1 && <1.1
 
 source-repository head
   type: git
@@ -70,6 +70,8 @@ test-suite doctests
   ghc-options:    -Wall -threaded
   hs-source-dirs: tests
   default-language: Haskell2010
+
+  x-doctest-options: -fobject-code
 
   if !flag(test-doctests)
     buildable: False

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -20,6 +20,6 @@ import Test.DocTest
 main :: IO ()
 main = do
     traverse_ putStrLn args
-    doctest $ "-fobject-code" : args
+    doctest args
   where
     args = flags ++ pkgs ++ module_sources


### PR DESCRIPTION
Should fix the build. Tested locally with the current state of `ghc-8.2` branch (of GHC: `fe5c821b2bded5ac6ddb17d94fdf66abe8a7952a`).