### PR TITLE
Avoid a dodgy `unsafeCoerce#` with GHC 9.4+

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+## next [????.??.??]
+* Avoid a particularly dodgy use of `unsafeCoerce#` in the implementation of
+  `isNil` when building with GHC 9.4 or later. This is necessary to make the
+  `isNil` function behave properly on GHC 9.6, as changes to GHC's optimizer in
+  9.6 make that use of `unsafeCoerce#` produce unexpected results at runtime.
+
 ## 0.1.6 [2021.04.30]
 * Make the test suite compile on recent GHCs.
 


### PR DESCRIPTION
Previously, `isNil` used `unsafeCoerce#` to coerce both of its arguments to `Any` before calling `reallyUnsafePtrEquality#` on it. This was necessary in previous GHCs because `reallyUnsafePtrEquality#` had an overly restrictive type that (1) requiring both of its arguments to have the same type, and (2) required the type of the arguments to be lifted. This was dangerous, however, because one of the coerced arguments was of type `SmallMutableArray#`, which has an unlifted return kind. Coercing to `Any` is only guaranteed to work when the type being coerced is a lifted type, and `SmallMutableArray#` is not a lifted type. By a lucky coincidence, this happened to work on previous GHCs, but this hack finally broke in GHC 9.6, as observed in https://gitlab.haskell.org/ghc/ghc/-/issues/22813.

Luckily, we no longer need to make use of this hack at all on recent GHCs. This is because `reallyUnsafePtrEquality#` now has a more general type that is levity polymorphic and heterogeneous, so we can call `reallyUnsafePtrEquality#` on its arguments without any intermediate coercions to `Any`. I have applied the appropriate CPP to make this happen, and I have confirmed that the `structs` test suite now passes with GHC 9.6.