### PR TITLE
Avoid dodgy `unsafeCoerce#`s in `SmallMutableArray#` functions

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+## next [????.??.??]
+* Avoid some dodgy uses of `unsafeCoerce#` from `Any` (a lifted type) to
+  `MutableByteArray# s` (an unlifted type) in the internals of the library.
+  While these uses of `unsafeCoerce#` have not been observed to cause any
+  improper behavior at runtime, the previous situation was rather delicate.
+
 ## 0.1.7 [2023.01.22]
 * Avoid a particularly dodgy use of `unsafeCoerce#` in the implementation of
   `isNil` when building with GHC 9.4 or later. This is necessary to make the

--- a/structs.cabal
+++ b/structs.cabal
@@ -53,6 +53,7 @@ library
     Data.Struct.Order
 
   ghc-options: -Wall -fwarn-monomorphism-restriction -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fno-warn-wrong-do-bind
+               -Wno-unticked-promoted-constructors
   hs-source-dirs: src
   default-language: Haskell2010
 


### PR DESCRIPTION
As explained in https://gitlab.haskell.org/ghc/ghc/-/issues/22813#note_479987, the definitions of `writeSmallMutableArraySmallArray#` _et al._ make use of some extremely dodgy unsafe coercions from `Any` (a lifted type) to `MutableByteArray# s` (an unlifted type), much in the same vein as #15. While I haven't managed to observe `structs` doing anything unexpected at runtime with these dodgy unsafe coercions, the current situation seems rather fragile.

Luckily, we can take advantage of the fact that `SmallMutableArray#` is levity polymorphic on GHC 9.4+ and instead cast from `SmallMutableArray# s Any` to `SmallMutableArray# s (MutableByteArray# s)`. Because these are both unlifted types, these coercions are on much much firmer footing. I have left an extensive comment to explain this reasoning next to the code itself.